### PR TITLE
Remove trailing code block

### DIFF
--- a/doc_source/aws-resource-certificatemanager-certificate.md
+++ b/doc_source/aws-resource-certificatemanager-certificate.md
@@ -118,4 +118,3 @@ mycert:
           - DomainName: example.com
             ValidationDomain: example.com
 ```
-```


### PR DESCRIPTION
Removes an extra set of backticks used for codeblocks that aren't required.